### PR TITLE
configure: Automaticaly detect the default xorg-module-dir.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,4 +21,8 @@
 # Author: Paulo Zanoni <pzanoni@mandriva.com>
 #
 
+# During distcheck, system locations (as provided by pkg-config) may
+# not be writable; provide instead relative locations.
+DISTCHECK_CONFIGURE_FLAGS = --with-xorg-module-dir='$${libdir}/xorg/modules'
+
 SUBDIRS = src

--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,12 @@ XORG_DEFAULT_OPTIONS
 LT_INIT([disable-static])
 
 # Define a configure option for an alternate module directory
-AC_ARG_WITH(xorg-module-dir, [  --with-xorg-module-dir=DIR ],
-                             [ moduledir="$withval" ],
-                             [ moduledir="$libdir/xorg/modules" ])
+PKG_PROG_PKG_CONFIG([0.25])
+AC_ARG_WITH(xorg-module-dir,
+            AS_HELP_STRING([--with-xorg-module-dir=DIR],
+                           [Default xorg module directory]),
+            [moduledir="$withval"],
+            [moduledir=`$PKG_CONFIG --variable=moduledir xorg-server`])
 AC_SUBST(moduledir)
 
 


### PR DESCRIPTION
The module directory has changed to a per ABI folder in the xlibre-xserver.
Now the default value of `xorg-module-dir` will be detected from the `moduledir` variable in xorg-server.pc.

Signed-off-by: b-aaz <b-aazbsd.proton.me>
